### PR TITLE
Local modifications to your own gitconfig symlink will be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vim/vim.symlink/.netrwhist
+git/gitconfig.symlink


### PR DESCRIPTION
Local modifications to your own gitconfig symlink will be ignored in the repo.

I'm assuming most people are copying gitconfig.sample to gitconfig.symlink and making their changes. The only problem arises is if they actually want to commit their gitconfig.symlink.
