### PR TITLE
grc.zsh references gls instead of grc

### DIFF
--- a/system/grc.zsh
+++ b/system/grc.zsh
@@ -1,5 +1,5 @@
 # GRC colorizes nifty unix tools all over the place
-if $(gls &>/dev/null)
+if $(grc &>/dev/null)
 then
   source `brew --prefix`/etc/grc.bashrc
 fi


### PR DESCRIPTION
Noticed this when I forked. My commits were too crazy to create sensible pull request.
