### PR TITLE
Uninstall task for Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,4 +33,25 @@ task :install do
     `ln -s "$PWD/#{linkable}" "#{target}"`
   end
 end
+
+task :uninstall do
+
+  Dir.glob('**/*.symlink').each do |linkable|
+
+    file = linkable.split('/').last.split('.symlink').last
+    target = "#{ENV["HOME"]}/.#{file}"
+
+    # Remove all symlinks created during installation
+    if File.symlink?(target)
+      FileUtils.rm(target)
+    end
+    
+    # Replace any backups made during installation
+    if File.exists?("#{ENV["HOME"]}/.#{file}.backup")
+      `mv "$HOME/.#{file}.backup" "$HOME/.#{file}"` 
+    end
+
+  end
+end
+
 task :default => 'install'


### PR DESCRIPTION
I'm a huge fan of your dotfiles system, but as I've been playing around with it, customizing my own, and encouraging others to try it out, I realized there was no quick, easy way to uninstall it and restore any backups made during the installation. So I added a rake uninstall task. Hope you find it helpful.
