### PR TITLE
Prompt: set unpushed using the preferred remote, not always origin.

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -28,7 +28,7 @@ git_prompt_info () {
 }
 
 unpushed () {
-  /usr/bin/git cherry -v origin/$(git_branch) 2>/dev/null
+  /usr/bin/git cherry -v `/usr/bin/git config --get branch.master.remote`/$(git_branch) 2>/dev/null
 }
 
 need_push () {


### PR DESCRIPTION
Hello Zach,

I'm sharing a small prompt enhancement for git projects that I fork on github. When I push to my repo, I don't like to see "with unpushed", since I will never push to origin, but probably always on my fork.

What do you think?
