### PR TITLE
Enhance unpushed by using upstream instead of trying to guess it.

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -28,7 +28,7 @@ git_prompt_info () {
 }
 
 unpushed () {
-  /usr/bin/git cherry -v `/usr/bin/git config --get branch.master.remote`/$(git_branch) 2>/dev/null
+  /usr/bin/git cherry -v @{upstream} 2>/dev/null
 }
 
 need_push () {


### PR DESCRIPTION
Looks like git has a shortcut to reference the upstream.

I was trying to make it better by getting both the remote and the merge ref from the config.

But this solution is sweet.
