### PR TITLE
Exclude 'master' from git-delete-local-merged targets

### DIFF
--- a/bin/git-delete-local-merged
+++ b/bin/git-delete-local-merged
@@ -5,4 +5,4 @@
 #
 #   https://plus.google.com/115587336092124934674/posts/dXsagsvLakJ
 
-git branch -d `git branch --merged | grep -v '^*' | tr -d '\n'`
+git branch -d `git branch --merged | grep -v '^*' | grep -v 'master' | tr -d '\n'`


### PR DESCRIPTION
I've accidentally deleted my master branch when I ran `git-delete-local-merged` from a topic branch. While I know better now, it shouldn't be an issue.
