### PR TITLE
use `xargs` to transform the multi-lines result to a single line

### DIFF
--- a/bin/git-delete-local-merged
+++ b/bin/git-delete-local-merged
@@ -5,4 +5,4 @@
 #
 #   https://plus.google.com/115587336092124934674/posts/dXsagsvLakJ
 
-git branch -d `git branch --merged | grep -v '^*' | grep -v 'master' | tr -d '\n'`
+git branch -d `git branch --merged | grep -v '^*' | grep -v 'master' | xargs`


### PR DESCRIPTION
If you just want to put the results on a single line, you can simply use `xargs`.
