### PR TITLE
Miscellaneous fixes to the `e` script

### DIFF
--- a/bin/e
+++ b/bin/e
@@ -16,7 +16,7 @@
 
 if test "$1" == ""
 then
-  $EDITOR .
+  exec $EDITOR .
 else
-  $EDITOR "$1"
+  exec $EDITOR "$1"
 fi


### PR DESCRIPTION
- Do not parse editor's stdout as a command.
- Avoid an extra sh process.

(I **had to** do this.)
