### PR TITLE
Addition of topic folders to fpath so they can define completion functions

### DIFF
--- a/zsh/fpath.zsh
+++ b/zsh/fpath.zsh
@@ -1,0 +1,2 @@
+#add each topic folder to fpath so that they can add functions and completion scripts
+for topic_folder ($ZSH/*) if [ -d $topic_folder ]; then  fpath=($topic_folder $fpath); fi;


### PR DESCRIPTION
By default to add completion functions zsh requires them to be in a folder defined in $fpath.  This adds all the topic folders to fpath so that completion functions can be organized in their topics.
