### PR TITLE
Symlinks created even if user skips

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,9 +24,10 @@ task :install do
         when 'O' then overwrite_all = true
         when 'B' then backup_all = true
         when 'S' then skip_all = true
-        when 's' then next
+        when 's' then skip = true
         end
       end
+      next if skip || skip_all
       FileUtils.rm_rf(target) if overwrite || overwrite_all
       `mv "$HOME/.#{file}" "$HOME/.#{file}.backup"` if backup || backup_all
     end


### PR DESCRIPTION
The rake-task `install` still tries to create the symlinks if the user selects `[S]kip all` for the conflicting targets. It's not a bug (since creating those symlinks just fails), but somewhat unexpected. This patch fixes that behaviour.
