### PR TITLE
Changed prompt to use git vs. /usr/bin/git for better portability

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -3,11 +3,11 @@ autoload colors && colors
 # http://github.com/ehrenmurdick/config/blob/master/zsh/prompt.zsh
 
 git_branch() {
-  echo $(/usr/bin/git symbolic-ref HEAD 2>/dev/null | awk -F/ {'print $NF'})
+  echo $(git symbolic-ref HEAD 2>/dev/null | awk -F/ {'print $NF'})
 }
 
 git_dirty() {
-  st=$(/usr/bin/git status 2>/dev/null | tail -n 1)
+  st=$(git status 2>/dev/null | tail -n 1)
   if [[ $st == "" ]]
   then
     echo ""
@@ -22,13 +22,13 @@ git_dirty() {
 }
 
 git_prompt_info () {
- ref=$(/usr/bin/git symbolic-ref HEAD 2>/dev/null) || return
+ ref=$(git symbolic-ref HEAD 2>/dev/null) || return
 # echo "(%{\e[0;33m%}${ref#refs/heads/}%{\e[0m%})"
  echo "${ref#refs/heads/}"
 }
 
 unpushed () {
-  /usr/bin/git cherry -v @{upstream} 2>/dev/null
+  git cherry -v @{upstream} 2>/dev/null
 }
 
 need_push () {


### PR DESCRIPTION
Change the prompt function to just use the `git` command vs. an absolute path to `/usr/bin/git`.  This lets the prompt work regardless of how git was installed on the machine or to where.  Macports for example puts it in `/opt/local/bin`
