### PR TITLE
Fixed zsh/zshrc.symlink

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -19,4 +19,4 @@ autoload -U compinit
 compinit
 
 # load every completion after autocomplete loads
-for config_file ($ZSH/**/completion.sh) source $config_file
+for config_file ($ZSH/**/completion.zsh) source $config_file


### PR DESCRIPTION
Last line should be "completion.zsh", not "completion.sh".
