### PR TITLE
Delay sourcing of completion.zsh files

### DIFF
--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -5,7 +5,7 @@ export ZSH=$HOME/.dotfiles
 export PROJECTS=~/Code
 
 # source every .zsh file in this rep
-for config_file ($ZSH/**/*.zsh) source $config_file
+for config_file ($ZSH/**/*.zsh) [[ "$(basename $config_file)" == "completion.zsh" ]] || source $config_file
 
 # use .localrc for SUPER SECRET CRAP that you don't
 # want in your public, versioned repo.


### PR DESCRIPTION
As it stands, `.zshrc` is sourcing completion.zsh files twice due to the recent rename of completion files from `completion.sh` to `completion.zsh`.  This is unintended, and with git installed via homebrew, sourcing `git/completion.zsh` the first time will cause two `command not found: compdef` errors.

I've attempted to fix the issue by sourcing zsh files the first time with:

``` shell
# source every .zsh file in this rep
for config_file ($ZSH/**/*.zsh) [[ "$(basename $config_file)" == "completion.zsh" ]] || source $config_file
```

This feels kind of hackish, but I do not know what the repercussions of sourcing all .zsh files at once rather than leaving completions for the end.
