### PR TITLE
Fix typo in the sublimetext config

### DIFF
--- a/sublime2/User/Base File.sublime-settings
+++ b/sublime2/User/Base File.sublime-settings
@@ -11,6 +11,6 @@
   "matchBracketsSquare": true,
   "rulers": [ 80 ],
   "show_minimap": false,
-  "trimTrailingWhiteSpaceOnSave": true,
+  "trim_trailing_white_space_on_save": true,
   "highlight_modified_tabs": true
 }


### PR DESCRIPTION
:bug: 

trimTrailingWhiteSpaceOnSave -> trim_trailing_white_space_on_save
