### PR TITLE
try to get the dirrect url from cloudapp using curl grep and sed

### DIFF
--- a/bin/mustacheme
+++ b/bin/mustacheme
@@ -50,7 +50,6 @@ do
   url=$(cloudapp $frame | grep Uploaded | awk '{print substr($0, index($0, "http://"))}')
   url="$url/$(basename $frame)"
   url="$(curl --silent $url | grep \"<a class=\\\"embed\\\" href=\\\"\" | sed -n -e 's/.*href=\"\(.*\)\".*/\\1/p')" 
-  echo $url
   wget "http://mustachify.me/?src=$url" -O "$frame-stache"
 done
 


### PR DESCRIPTION
This is NOT working yet... I can get this line to work at my shell with 

```
› echo "curl --silent http://cl.ly/LCKb | grep \"<a class=\\\"embed\\\" href=\\\"\" | sed -n -e 's/.*href=\"\(.*\)\".*/\\1/p'" | sh

```

but i cant figure out why it doesn't work the way i used in mustacheme.

Maybe this could be more efficient? I kinda just did what i could with my lack of awk/sed/grep knowledge
