### PR TITLE
try to get the direct url from cloudapp using curl grep and sed

### DIFF
--- a/bin/mustacheme
+++ b/bin/mustacheme
@@ -49,6 +49,7 @@ for frame in $output/*.gif
 do
   url=$(cloudapp $frame | grep Uploaded | awk '{print substr($0, index($0, "http://"))}')
   url="$url/$(basename $frame)"
+  url="$(curl --silent $url | grep \"<a class=\\\"embed\\\" href=\\\"\" | sed -n -e 's/.*href=\"\(.*\)\".*/\\1/p')" 
   wget "http://mustachify.me/?src=$url" -O "$frame-stache"
 done
 


### PR DESCRIPTION
not working yet... seems to be an escaping problem

```
echo "curl --silent http://cl.ly/LCKb | grep \"<a class=\\\"embed\\\" href=\\\"\" | sed -n -e 's/.*href=\"\(.*\)\".*/\\1/p'" | sh
```

works but when i add $() around instead of using `| sh` it fails

```
echo "$(curl --silent http://cl.ly/LCKb | grep \"<a class=\\\"embed\\\" href=\\\"\" | sed -n -e 's/.*href=\"\(.*\)\".*/\\1/p')"  
zsh: no such file or directory: a
```

any insight on why my escaping is failing? Does it have to do with the pipes?
