### PR TITLE
Make bin/e compatible with more shells

### DIFF
--- a/bin/e
+++ b/bin/e
@@ -14,8 +14,7 @@
 #   $ e /usr/local
 #   # => opens the specified directory in your editor
 
-if test "$1" == ""
-then
+if [ "$1" == "" ] ; then
   exec $EDITOR .
 else
   exec $EDITOR "$1"


### PR DESCRIPTION
The revision is similar to pull request #49 in that it more strictly follows the POSIX standard for shell scripts by not using "test". 

Small change, but it means bin/e will work with more shells on more systems (e.g.
Ubuntu 8+ which links **/bin/sh** to **/bin/dash** by default).
