### PR TITLE
Update prompt git status check

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -12,7 +12,7 @@ git_dirty() {
   then
     echo ""
   else
-    if [[ $st == "nothing to commit (working directory clean)" ]]
+    if [[ "$st" =~ ^nothing ]]
     then
       echo "on %{$fg_bold[green]%}$(git_prompt_info)%{$reset_color%}"
     else


### PR DESCRIPTION
git 1.8.1 gives a different status message when there's nothing to commit. Checking for a line beginning with 'nothing' works for old version and new version, and hopefully prepares the statement for changes in the future.
