### PR TITLE
Try for git from zsh $commands before we hard fail back to the system /usr/bin/git.

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -2,12 +2,19 @@ autoload colors && colors
 # cheers, @ehrenmurdick
 # http://github.com/ehrenmurdick/config/blob/master/zsh/prompt.zsh
 
+if (( $+commands[git] ))
+then
+  git=$commands[git]
+else
+  git=/usr/bin/git
+fi
+
 git_branch() {
-  echo $(/usr/bin/git symbolic-ref HEAD 2>/dev/null | awk -F/ {'print $NF'})
+  echo $($git symbolic-ref HEAD 2>/dev/null | awk -F/ {'print $NF'})
 }
 
 git_dirty() {
-  st=$(/usr/bin/git status 2>/dev/null | tail -n 1)
+  st=$($git status 2>/dev/null | tail -n 1)
   if [[ $st == "" ]]
   then
     echo ""
@@ -22,13 +29,13 @@ git_dirty() {
 }
 
 git_prompt_info () {
- ref=$(/usr/bin/git symbolic-ref HEAD 2>/dev/null) || return
+ ref=$($git symbolic-ref HEAD 2>/dev/null) || return
 # echo "(%{\e[0;33m%}${ref#refs/heads/}%{\e[0m%})"
  echo "${ref#refs/heads/}"
 }
 
 unpushed () {
-  /usr/bin/git cherry -v @{upstream} 2>/dev/null
+  $git cherry -v @{upstream} 2>/dev/null
 }
 
 need_push () {


### PR DESCRIPTION
Since homebrew installs git executable to /usr/local/bin instead of /usr/bin, lets try for ZSH's $commands[git] before we blindly use /usr/bin/git.
