### PR TITLE
Use bash not zsh or sh.

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 #
 # bootstrap installs things.
 


### PR DESCRIPTION
So this will fix both #76 and #77 for real.

On Mac OS X /bin/sh is actually a sophisticated ploy of hard linking to a bash shell, aka using `#!/bin/sh` is just like using `#!/bin/bash` in this case.

When you turn around and use `#!/bin/sh` on a Linux machine, your chances are high to actually be using the _sh shell_.
#76 fails because read is not a builtin for the sh shell but for more programmable shells, like bash and zsh.
#77 fails because the user does not have zsh installed yet. This is under assumption from the information given in the issue's original remarks.
