### PR TITLE
Nest helper under credential

### DIFF
--- a/git/gitconfig.symlink.example
+++ b/git/gitconfig.symlink.example
@@ -6,6 +6,7 @@
 [user]
         name = AUTHORNAME
         email = AUTHOREMAIL
+[credential]
         helper = osxkeychain
 [alias]
         co = checkout


### PR DESCRIPTION
I noticed this when git kept asking me for user/pass.
It seems helper was under the wrong namespace
