### PR TITLE
Updated bin/git-track for git 1.8

### DIFF
--- a/bin/git-track
+++ b/bin/git-track
@@ -4,4 +4,4 @@
 # `origin/$branch-name`.
 
 branch=$(git rev-parse --abbrev-ref HEAD)
-git branch --set-upstream $branch origin/$branch
+git branch $branch --set-upstream-to origin/$branch


### PR DESCRIPTION
Just a quick pull request to fix the issue of `--set-upstream` being renamed to `--set-upstream-to` as per #83.
