### PR TITLE
Update gitconfig.symlink.example

### DIFF
--- a/git/gitconfig.symlink.example
+++ b/git/gitconfig.symlink.example
@@ -14,6 +14,7 @@
         wtf     = !$ZSH/bin/git-wtf
         rank-contributers = !$ZSH/bin/git-rank-contributers
         count   = !git shortlog -sn
+        git = !git
 [color]
         diff = auto
         status = auto


### PR DESCRIPTION
Added alias for `git` so you can fatthumb `git git <command>` and it'll still work! :)

Before: 

``` bash
$ git git status
WARNING: You called a Git command named 'git', which does not exist.
```

After:

``` bash
$ git git status
# On branch master
nothing to commit, working directory clean
```

It's recursive so if somehow you manage to type it multiple times, it still works!

``` bash
$ git git git git git git git git git status
# On branch status
nothing to commit, working directory clean
```

I learnt it from this Coderwall post https://coderwall.com/p/gx8jrg
