### PR TITLE
Fix movieme for videos whose pixel aspect ratio and display aspect ratio don't match

### DIFF
--- a/bin/movieme
+++ b/bin/movieme
@@ -24,7 +24,7 @@ rm -rf /tmp/movieme
 mkdir -p /tmp/movieme
 
 # split the movie into constituent frames
-ffmpeg -i $1 -f image2 -ss $2 -t $3 -r 7 /tmp/movieme/d-%05d.png
+ffmpeg -i $1 -f image2 -vf "scale=iw*sar:ih" -ss $2 -t $3 -r 7 /tmp/movieme/d-%05d.png
 
 # ANIMATE
 gifme /tmp/movieme/* -d 0


### PR DESCRIPTION
Some video files are stored with a different aspect ratio to how they are intended to display.

It's usually to get around the fixed pixel size divisibility requirements of a video codec.

This changes the `ffmpeg` call to scale the frames extracted to the aspect ratio they would otherwise be shown at.
