### PR TITLE
Better portability

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # bootstrap installs things.
 


### PR DESCRIPTION
Use env(1) to locate shell binary (see http://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability) - so it would work fine in FreeBSD and other systems with bash(1) binary placed not at /bin/bash, but at /usr/bin/bash or somewhere other.
