### PR TITLE
Add support for rvm-prompt to rb_prompt()

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -50,9 +50,19 @@ need_push () {
 rb_prompt(){
   if (( $+commands[rbenv] ))
   then
-	  echo "%{$fg_bold[yellow]%}$(rbenv version | awk '{print $1}')%{$reset_color%}"
-	else
-	  echo ""
+    rbcmd=rbenv
+  else
+    if (( $+commands[rvm-prompt] ))
+    then
+      rbcmd=rvm-prompt
+    fi
+  fi
+
+  if (($+rbcmd))
+  then
+    echo "%{$fg_bold[yellow]%}$($rbcmd | awk '{print $1}')%{$reset_color%}"
+  else
+    echo ""
   fi
 }
 


### PR DESCRIPTION
A lot of people still use and prefer RVM, so I thought it would be nice to show the ruby version.
