### PR TITLE
Updated prompt with idea from Issue #71

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -96,7 +96,7 @@ directory_name() {
                 PROMPT_PATH=""
             else
                 # We're not in the root. Display the git repo root.
-                GIT_ROOT="%{$fg_bold[bluecd]%}${BASE}%{$reset_color%}"
+                GIT_ROOT="%{$fg_bold[blue]%}${BASE}%{$reset_color%}"
 
                 PATH_TO_CURRENT="${PWD#$(git rev-parse --show-toplevel)}"
                 PATH_TO_CURRENT="${PATH_TO_CURRENT%/*}"


### PR DESCRIPTION
The prompt now displays the directory up to 3 levels deep if not in ~ or /. Also when entering a git repo or submodule it will show the dir structure up to its root! quite nifty.

plz see [stackoverflow](http://stackoverflow.com/questions/16147173/command-prompt-directory-styling) or #issue71
