### PR TITLE
Updating `grm` alias to support rm of resources where path contains spaces

### DIFF
--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -16,4 +16,5 @@ alias gca='git commit -a'
 alias gco='git checkout'
 alias gb='git branch'
 alias gs='git status -sb' # upgrade your git if -sb breaks for you. it's fun.
-alias grm="git status | grep deleted | awk '{print \$3}' | xargs git rm"
+alias grm="git status | grep deleted | awk '{\$1=\$2=\"\"; print \$0}' | \
+           sed 's/^[ \t]*//' | sed 's/ /\\\\ /g' | xargs git rm"


### PR DESCRIPTION
`awk '{print $3}'` will give us the path following `deleted:` in the git status
output, but not the full path if it contains spaces. `awk '{$1=$2=""; print $0}'` effectively removes `#` and `deleted:` from the grepped line, allowing us to retrieve the remainder with `$0`. Following this we filter out spaces at the beginning of the line and escape all remaining
spaces with `awk` and `sed`.

I suppose this could be done more elegantly (maybe `awk '{print substr($0, 0, N)}'` where `N` is equal to the number of characters preceding our desired path), but I honestly can't be certain (i.e. is it always 14 characters? what about tabs?). Probably a noob issue...
