### PR TITLE
Auto run all install.sh scripts

### DIFF
--- a/script/install
+++ b/script/install
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Run all dotfiles installers.
+
+set -e
+
+cd "$(dirname $)"/..
+
+# find the installers and run them iteratively
+find . -name install.sh | while read installer ; do sh -c "${installer}" ; done


### PR DESCRIPTION
This adds a `script/install` that iteratively runs all `install.sh`scripts located in the dotfiles directory. Solves @holman's request from commit f697ba7
