### PR TITLE
Add restart-services to osx

### DIFF
--- a/bin/restart-services
+++ b/bin/restart-services
@@ -1,0 +1,5 @@
+#!/bin/sh
+#
+# Restarts OS X services affected running $ZSH/osx/set-defaults.sh.
+
+exec $ZSH/osx/restart-services.sh

--- a/bin/set-defaults
+++ b/bin/set-defaults
@@ -2,4 +2,28 @@
 #
 # Sets OS X defaults by running $ZSH/osx/set-defaults.sh.
 
-exec $ZSH/osx/set-defaults.sh
+sh $ZSH/osx/set-defaults.sh &&
+
+printf '\r  [ \033[0;33m?\033[0m ] - Do you want to restart affected services? [yn] '
+read -e restart
+
+should_restart=false
+
+shopt -s nocasematch
+
+if [[ $restart == "y" ]]
+then
+  should_restart=true
+fi
+
+if [[ $restart == "yes" ]]
+then
+  should_restart=true
+fi
+
+shopt -u nocasematch
+
+if $should_restart
+then
+  exec $ZSH/osx/restart-services.sh
+fi

--- a/osx/restart-services.sh
+++ b/osx/restart-services.sh
@@ -1,0 +1,15 @@
+# Restarts services affected by `./osx/set-defaults.sh`.
+
+# Ask for the administrator password upfront
+sudo -v
+
+# Keep-alive: update existing `sudo` time stamp until `restart-services.sh` has finished
+while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
+
+echo "\nRestarting services affected by \`set-defaults.sh\`. If you are using Terminal.app, it will close when finished. Note that some of the defaults changes still require a logout/restart to take effect."
+
+sleep 5
+
+for app in "Dock" "Finder" "Safari" "SystemUIServer" "Terminal"; do
+  killall "$app" > /dev/null 2>&1
+done

--- a/osx/set-defaults.sh
+++ b/osx/set-defaults.sh
@@ -5,7 +5,7 @@
 # The original idea (and a couple settings) were grabbed from:
 #   https://github.com/mathiasbynens/dotfiles/blob/master/.osx
 #
-# Run ./set-defaults.sh and you'll be good to go.
+# Run ./bin/set-defaults and you'll be good to go.
 
 # Disable press-and-hold for keys in favor of key repeat.
 defaults write -g ApplePressAndHoldEnabled -bool false


### PR DESCRIPTION
Adds a simple script to allow users to optionally restart the services changed by running `osx/set-defaults` so that they don't have to do a full system restart to see the new defaults take effect.

The script can be executed via `bin/restart-services`, or by choice once `bin/set-defaults` has finished running. `osx/set-defaults` runs as it did before, so `script/bootstrap` and `bin/dot` are not changed by this new script (to avoid having the Terminal killed before they finish running).
