### PR TITLE
Remove autocompletion for deleted `h` function

### DIFF
--- a/functions/_h
+++ b/functions/_h
@@ -1,2 +1,0 @@
-#compdef h
-_files -W ~ -/


### PR DESCRIPTION
Just a bit of cleanup now that the `h` function is no more...  :bath:
