### PR TITLE
Only look for install.sh scripts in dotfile root dirs.

### DIFF
--- a/script/install
+++ b/script/install
@@ -2,9 +2,9 @@
 #
 # Run all dotfiles installers.
 
+DOTFILES_ROOT="`pwd`"
+
 set -e
 
-cd "$(dirname $)"/..
-
 # find the installers and run them iteratively
-find . -name install.sh | while read installer ; do sh -c "${installer}" ; done
+find $DOTFILES_ROOT -name install.sh | while read installer ; do sh -c "${installer}" ; done


### PR DESCRIPTION
This follows the same pattern as script/bootstrap by explicitly only
looking under dotfile root dirs for the install.sh scripts.

Looking in the parent directory can find unrelated install.sh not intended
to be executed (which is what happened to me :), when I was in .dotfiles
and ran `scripts/install`.
