### PR TITLE
Update the me method for general use

### DIFF
--- a/ruby/irbrc.symlink
+++ b/ruby/irbrc.symlink
@@ -15,7 +15,7 @@ class Object
   def local_methods(obj = self)
     (obj.methods - obj.class.superclass.instance_methods).sort
   end
-  
+
   # print documentation
   #
   #   ri 'Array#pop'
@@ -32,7 +32,7 @@ class Object
 end
 
 def me
-  User.find_by_login('holman')
+  User.find_by_login(ENV['USER'].strip)
 end
 
 def r


### PR DESCRIPTION
Updates the `me` method in `ruby/irbrc.symlink` to read the user login from the local machine username (rather than hard-coding "holman") :smile: 
