### PR TITLE
Only call rbenv init if installed

### DIFF
--- a/ruby/rbenv.zsh
+++ b/ruby/rbenv.zsh
@@ -1,2 +1,5 @@
 # init according to man page
-eval "$(rbenv init -)"
+if (( $+commands[rbenv] ))
+then
+  eval "$(rbenv init -)"
+fi


### PR DESCRIPTION
This prevents some errors on systems where rbenv is not installed (copies syntax from the hub integration)
