### PR TITLE
Better `cd` in installer

### DIFF
--- a/script/install
+++ b/script/install
@@ -4,7 +4,7 @@
 
 set -e
 
-cd "$(dirname $)"/..
+cd "$(dirname $0)"/..
 
 # find the installers and run them iteratively
 find . -name install.sh | while read installer ; do sh -c "${installer}" ; done


### PR DESCRIPTION
With `cd "$(dirname $)"/..` it works bad, because `$(dirname $)` will return `.` so it implies that to correctly works, you have to be in the `script` directory, otherwise if you're e.g. in `$HOME/.dotfiles` you'll go in `$HOME` and then look for all `install.sh`, which may not be what you intended to do (for instance, there are a `install.sh` in oh-my-zsh that I don't want to be run).

Using `$(dirname $0)` instead ensure that you'll go one level higher than the `install` script.
