### PR TITLE
Only source grc if grc and brew are installed

### DIFF
--- a/system/grc.zsh
+++ b/system/grc.zsh
@@ -1,5 +1,5 @@
 # GRC colorizes nifty unix tools all over the place
-if $(grc &>/dev/null) && ! $(brew &>/dev/null)
+if (( $+commands[grc] )) && (( $+commands[brew] ))
 then
   source `brew --prefix`/etc/grc.bashrc
 fi


### PR DESCRIPTION
This switches the test to our favorite format and thus better supports Ubuntu (and probably other linuxes)...  :cake: 
