### PR TITLE
Misspeled git rank-contributors alias

### DIFF
--- a/git/gitconfig.symlink.example
+++ b/git/gitconfig.symlink.example
@@ -12,7 +12,7 @@
         co = checkout
         promote = !$ZSH/bin/git-promote
         wtf     = !$ZSH/bin/git-wtf
-        rank-contributers = !$ZSH/bin/git-rank-contributers
+        rank-contributors = !$ZSH/bin/git-rank-contributors
         count   = !git shortlog -sn
 [color]
         diff = auto


### PR DESCRIPTION
Correct alias for `bin/git-rank-contributors`
