### PR TITLE
Fix "git status" parsing in prompt for git 1.8.5

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -14,12 +14,12 @@ git_branch() {
 }
 
 git_dirty() {
-  st=$($git status 2>/dev/null | tail -n 1)
-  if [[ $st == "" ]]
+  st=$($git status --porcelain 2>/dev/null)
+  if [[ "$st" =~ ^fatal ]]
   then
     echo ""
   else
-    if [[ "$st" =~ ^nothing ]]
+    if [[ $st == "" ]]
     then
       echo "on %{$fg_bold[green]%}$(git_prompt_info)%{$reset_color%}"
     else


### PR DESCRIPTION
With the release of git 1.8.5 they are removing the `#` symbol from the output of `git status`.  This causes an issue when there are staged files to be committed where `git_dirty()` returns an empty string thus causing the branch information to disappear from the prompt.

Looking through the changelog they recommend using `git status --porcelain` to parse from because the out is more stable.  To that end I've attempted to do that, and wanted to submit it back.
