### PR TITLE
Replace "." with "source" in script/bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -127,7 +127,7 @@ install_dotfiles
 if [ "$(uname -s)" == "Darwin" ]
 then
   info "installing dependencies"
-  if . bin/dot > /tmp/dotfiles-dot 2>&1
+  if source bin/dot > /tmp/dotfiles-dot 2>&1
   then
     success "dependencies installed"
   else


### PR DESCRIPTION
Removing esoteric `.` with explicit `source` as per my last comment in #109.
