### PR TITLE
Correctly identify git repo when all changes are staged

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -14,7 +14,7 @@ git_branch() {
 }
 
 git_dirty() {
-  st=$($git status 2>/dev/null | tail -n 1)
+  st=$($git status 2>/dev/null | tail +4 | head -n 1)
   if [[ $st == "" ]]
   then
     echo ""


### PR DESCRIPTION
Currently, when the git repo is in a state where all changes are staged, the last line of `git status` will return a blank line. This causes the git_dirty function to incorrectly return an empty string, which makes the directory look like a non-git repo.

Try it out in any directory, stage all your changes and notice how the branch name in the prompt disappears.

```
⇨  git --version                                                                  master
git version 1.8.5.2 (Apple Git-48)
```
