### PR TITLE
Determine DOTFILES_ROOT correctly

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,8 @@
 #
 # bootstrap installs things.
 
-DOTFILES_ROOT="`pwd`"
+cd "$(dirname "$0")/.."
+DOTFILES_ROOT=$(pwd)
 
 set -e
 
@@ -60,7 +61,7 @@ install_dotfiles () {
   backup_all=false
   skip_all=false
 
-  for source in `find $DOTFILES_ROOT -maxdepth 2 -name \*.symlink`
+  for source in `find . -maxdepth 2 -name \*.symlink`
   do
     dest="$HOME/.`basename \"${source%.*}\"`"
 


### PR DESCRIPTION
In case `script/bootstrap` is run not from `.dotfiles` it does weird things while trying to setup git (even if git doesn't need any setup).

This is somewhat like #127, only better.
