### PR TITLE
$XDG_CONFIG_DIR and a bit of code reorganisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ There's a few special files in the hierarchy.
   your `$HOME`. This is so you can keep all of those versioned in your dotfiles
   but still keep those autoloaded files in your home directory. These get
   symlinked in when you run `script/bootstrap`.
+- **topic/\*.config**: Any files ending in `*.config` get symlinked to
+  `$XDG_CONFIG_HOME/topic/`.
 
 ## bugs
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -121,6 +121,19 @@ install_dotfiles () {
     dst="$HOME/.$(basename "${src%.*}")"
     link_file "$src" "$dst"
   done
+
+  for app in */
+  do
+    app=${app%/}
+    for file in $(find "$app" -mindepth 1 -maxdepth 1 -name '*.config' -printf '%f ')
+    do
+      src="$DOTFILES_ROOT/$app/$file"
+      appdir="${XDG_CONFIG_HOME:-$HOME/.config}/$app"
+      dst="$appdir/$(basename "${src%.*}")"
+      mkdir -p "$appdir"
+      link_file "$src" "$dst"
+    done
+  done
 }
 
 setup_gitconfig


### PR DESCRIPTION
Here is support for linking `<app>/<foo>.config` → `$XDG_CONFIG_DIR/<app>/<foo>`. If you really don't like the idea of XDG, at least now you know where to get it once you decide you want it ;).
I hope you can merge all the commits except for the last one anyway.

I tried to make all the changes in a number of small steps easy to verify by eyes. I also did some testing this time :cat:.
