### PR TITLE
--no-ri --no-rdoc is deprecated, use --no-document

### DIFF
--- a/ruby/gemrc.symlink
+++ b/ruby/gemrc.symlink
@@ -4,4 +4,4 @@
 :bulk_threshold: 1000
 :backtrace: false
 :benchmark: false
-gem: --no-ri --no-rdoc
+gem: --no-document


### PR DESCRIPTION
/ruby/gemrc.symlink :
this cofiguration was using 'gem: --no-ri --no-rdoc' to avoid
installation of docs with gems, but this method is now deprecated
changed it to new official way => 'gem: --no-document'

can you review this, please :neutral_face: 
