### PR TITLE
Removed deprecated bulk_threshold-instance method

### DIFF
--- a/ruby/gemrc.symlink
+++ b/ruby/gemrc.symlink
@@ -1,7 +1,6 @@
 --- 
 :update_sources: true
 :verbose: true
-:bulk_threshold: 1000
 :backtrace: false
 :benchmark: false
 gem: --no-document


### PR DESCRIPTION
http://www.rubydoc.info/github/rubygems/rubygems/Gem/ConfigFile#bulk_threshold-instance_method
