### PR TITLE
Fix git-rank-contributors for invalid encodings

### DIFF
--- a/bin/git-rank-contributors
+++ b/bin/git-rank-contributors
@@ -8,7 +8,7 @@
 ## Probably not without some editing, because people often commit from more
 ## than one address.
 ##
-## git-rank-contributors Copyright 2008 William Morgan <wmorgan-git-wt-add@masanjin.net>. 
+## git-rank-contributors Copyright 2008 William Morgan <wmorgan-git-wt-add@masanjin.net>.
 ## This program is free software: you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by
 ## the Free Software Foundation, either version 3 of the License, or (at
@@ -34,7 +34,13 @@ htmlize = ARGV.delete("-h")
 
 author = nil
 state = :pre_author
-`git log -M -C -C -p --no-color`.split("\n").each do |l|
+log = `git log -M -C -C -p --no-color`
+# Fix for invalid encodings
+# http://stackoverflow.com/a/24037885
+if !log.valid_encoding?
+  log = log.encode("UTF-16be", :invalid => :replace, :replace => "?").encode('UTF-8')
+end
+log.split("\n").each do |l|
   case
   when (state == :pre_author || state == :post_author) && l =~ /Author: (.*)$/
     author = $1

--- a/bin/git-rank-contributors
+++ b/bin/git-rank-contributors
@@ -25,6 +25,16 @@
 class String
   def obfuscate; gsub(/@/, " at the ").gsub(/\.(\w+)(>|$)/, ' dot \1s\2') end
   def htmlize; gsub("&", "&amp;").gsub("<", "&lt;").gsub(">", "&gt;") end
+  # Fix for invalid encodings http://stackoverflow.com/a/24037885
+  def clean
+    if RUBY_VERSION >= "2.1"
+      scrub
+    elsif RUBY_VERSION >= "1.9"
+      encode("UTF-16be", :invalid => :replace).encode("UTF-8")
+    else
+      self
+    end
+  end
 end
 
 lines = {}
@@ -34,13 +44,7 @@ htmlize = ARGV.delete("-h")
 
 author = nil
 state = :pre_author
-log = `git log -M -C -C -p --no-color`
-# Fix for invalid encodings
-# http://stackoverflow.com/a/24037885
-if !log.valid_encoding?
-  log = log.encode("UTF-16be", :invalid => :replace, :replace => "?").encode('UTF-8')
-end
-log.split("\n").each do |l|
+`git log -M -C -C -p --no-color`.clean.split("\n").each do |l|
   case
   when (state == :pre_author || state == :post_author) && l =~ /Author: (.*)$/
     author = $1


### PR DESCRIPTION
Sometimes, git logs have invalid encodings. When I try to run `git rank-contributors` on repositories with such logs, I get this error message:
```bash
/path/to/git-rank-contributors:37:in `split': invalid byte sequence in UTF-8 (ArgumentError)
	from /path/to/git-rank-contributors:37:in `<main>'
```
This pull request fixes the problem using a solution found on [StackOverflow](http://stackoverflow.com/a/24037885).