### PR TITLE
Load ~/.env-vars before ~/.localrc and the config files

### DIFF
--- a/private/env-vars.zsh
+++ b/private/env-vars.zsh
@@ -1,8 +1,0 @@
-# Stash your environment variables in ~/.env-vars. This means they'll stay out
-# of your main dotfiles repository (which may be public, like this one), but
-# you'll have access to them in your scripts.
-if [[ -a ~/.env-vars ]]
-then
-  source ~/.env-vars
-fi
-

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -4,6 +4,14 @@ export ZSH=$HOME/.dotfiles
 # your project folder that we can `c [tab]` to
 export PROJECTS=~/Code
 
+# Stash your environment variables in ~/.env-vars. This means they'll stay out
+# of your main dotfiles repository (which may be public, like this one), but
+# you'll have access to them in your scripts.
+if [[ -a ~/.env-vars ]]
+then
+  source ~/.env-vars
+fi
+
 # use .localrc for SUPER SECRET CRAP that you don't
 # want in your public, versioned repo.
 if [[ -a ~/.localrc ]]


### PR DESCRIPTION
Fixes issue reported at
https://github.com/holman/dotfiles/commit/f5fbf5de3f5a6ecfc60814397014e13b24b398b9#commitcomment-9506982 where environment variables defined in `~/.env-vars` are not surfaced to the config files named `path.zsh` and are not available to config files that come after `private/env-vars.zsh` alphabetically.