### PR TITLE
Added '/' to find command to handle symlinked .dotfiles folder

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -130,7 +130,7 @@ install_dotfiles () {
 
   local overwrite_all=false backup_all=false skip_all=false
 
-  for src in $(find "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink')
+  for src in $(find "$DOTFILES_ROOT/" -maxdepth 2 -name '*.symlink')
   do
     dst="$HOME/.$(basename "${src%.*}")"
     link_file "$src" "$dst"


### PR DESCRIPTION
Right now, `script/bootstrap` *silently* fails to symlink anything when `$DOTFILES_ROOT` is itself a symlink, at least on my Mac.

This seems to boil down to the 'find' command: it doesn't recurse into a symlink unless the symlink ends with a trailing slash.

In other words:

```zsh
$ ln -s dotfiles ~/.dotfiles
$ find ~/.dotfiles -name '*.symlink'
# Nothing found, because ~/.dotfiles is *not* treated as a directory
$find ~/.dotfiles/ -name '*.symlink'
...
# Files are found, because ~/.dotfiles/ *is* treated as a directory
```

I have a "shared" directory with a virtual machine that I like to use for all code-type projects, so I wanted to put the dotfiles there, symlink it from `~/.dotfiles`, and then treat `~/.dotfiles` as `$DOTFILES_ROOT`. Unfortunately,  the silent failure caught me, so... I thought someone should fix that. 