### PR TITLE
fix atom workspace config to be atom 1.0 compliant

### DIFF
--- a/atom.symlink/init.coffee
+++ b/atom.symlink/init.coffee
@@ -1,6 +1,5 @@
 path = require 'path'
 
-atom.workspaceView.eachEditorView (editorView) ->
-  editor = editorView.getEditor()
+atom.workspace.observeTextEditors (editor) ->
   if path.extname(editor.getPath()) is '.md'
     editor.setSoftWrap(true)


### PR DESCRIPTION
Recent changes in Atom's API were raising a warning in the deprecation cop: `atom.workspaceView is no longer available`. Minor changes were required to bring it back into compliance with the Atom 1.0 API.