### PR TITLE
fix / in bootstrap, rearrange prompt.zsh

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -130,7 +130,7 @@ install_dotfiles () {
 
   local overwrite_all=false backup_all=false skip_all=false
 
-  for src in $(find "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink')
+  for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink')
   do
     dst="$HOME/.$(basename "${src%.*}")"
     link_file "$src" "$dst"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -130,7 +130,7 @@ install_dotfiles () {
 
   local overwrite_all=false backup_all=false skip_all=false
 
-  for src in $(find "$DOTFILES_ROOT/" -maxdepth 2 -name '*.symlink')
+  for src in $(find "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink')
   do
     dst="$HOME/.$(basename "${src%.*}")"
     link_file "$src" "$dst"

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -71,7 +71,6 @@ directory_name() {
   echo "%{$fg_bold[cyan]%}%1/%\/%{$reset_color%}"
 }
 
-export PROMPT=$'\n$(rb_prompt)in $(directory_name) $(git_dirty)$(need_push)\n› '
 set_prompt () {
   export RPROMPT="%{$fg_bold[cyan]%}%{$reset_color%}"
 }
@@ -80,3 +79,5 @@ precmd() {
   title "zsh" "%m" "%55<...<%~"
   set_prompt
 }
+
+export PROMPT=$'\n$(rb_prompt)in $(directory_name) $(git_dirty)$(need_push)\n› '

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -39,3 +39,5 @@ do
 done
 
 unset config_files
+
+export PATH="$PATH:$HOME/.rvm/bin" # Add RVM to PATH for scripting

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -39,4 +39,3 @@ do
 done
 
 unset config_files
-

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -40,4 +40,3 @@ done
 
 unset config_files
 
-export PATH="$PATH:$HOME/.rvm/bin" # Add RVM to PATH for scripting


### PR DESCRIPTION
1) There seems to be an extra '/' in the bootstrap script
2) prompt.zsh needed re arrangement
3) added export to rvm to zshrc.symlink