### PR TITLE
Fix the extra trailing '/' for symlinks

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -130,7 +130,7 @@ install_dotfiles () {
 
   local overwrite_all=false backup_all=false skip_all=false
 
-  for src in $(find "$DOTFILES_ROOT/" -maxdepth 2 -name '*.symlink')
+  for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink')
   do
     dst="$HOME/.$(basename "${src%.*}")"
     link_file "$src" "$dst"


### PR DESCRIPTION
Following issues for pull requests #186 and #192 .
Using the find flag '-H', which allows for following symlinks if the input is itself a symlink, without having to add any extra '/' that appears everywhere with all the symlinks. (Tested on Mac and Debian Linux) 
pull request #192  should be closed since I did change multiple files and the whole commit was messed up