### PR TITLE
Exclude .git from symlink search

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -130,7 +130,7 @@ install_dotfiles () {
 
   local overwrite_all=false backup_all=false skip_all=false
 
-  for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink')
+  for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink' -not -path '*.git*')
   do
     dst="$HOME/.$(basename "${src%.*}")"
     link_file "$src" "$dst"


### PR DESCRIPTION
I encountered problems with git submodules in my fork of your dotfile framework and thought others might find my fix useful.

Concretely, I had a submodule in my sublime config at path `DOTFILES_ROOT/config/sublime/config/sublime-text-3.symlink/Packages/User/SublimeLinter-contrib-hdevtools` which resulted in a similar directory structure underneath `.git/modules/`. This path was then found when boostrapping the dotfiles. Excluding paths inside git config folders, i.e. `.git`, resolves this.