### PR TITLE
Added ability to link .config/* files while keeping topical structure

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -137,8 +137,21 @@ install_dotfiles () {
   done
 }
 
+install_xdg () {
+  info 'installing xdg config'
+
+  local overwrite_all=false backup_all=false skip_all=false
+
+  for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.conflink' -not -path '*.git*')
+  do
+    dst="$HOME/.config/$(basename "${src%.*}")"
+    link_file "$src" "$dst"
+  done
+}
+
 setup_gitconfig
 install_dotfiles
+install_xdg
 
 # If we're on a Mac, let's install and setup homebrew.
 if [ "$(uname -s)" == "Darwin" ]


### PR DESCRIPTION
There are some programs that use a .config/myapp/myapp.conf style (e.g., nvim, mopidy, ncmpcpp, etc). This adds another suffix, .conflink, which behaves almost exactly like a .symlink except it puts the folder / file under the .config root and does not prefix with a dot. Topical folders without a suffix still behave appropriately.

For example, I have a nvim topical folder, and that has my nvim.conflink (containing files such as my init.vim file). So the result of running the bootstrap is ~/.config/nvim --> ~/.dotfiles/nvim/nvim.conflink