### PR TITLE
Alias for adding + committing

### DIFF
--- a/git/aliases.zsh
+++ b/git/aliases.zsh
@@ -17,3 +17,4 @@ alias gco='git checkout'
 alias gcb='git copy-branch-name'
 alias gb='git branch'
 alias gs='git status -sb' # upgrade your git if -sb breaks for you. it's fun.
+alias gac='git add -A && git commit -m'


### PR DESCRIPTION
My go-to commit alias.

Usage: `$ gac "Initial commit"`.