### PR TITLE
[Fix] Make git.io URL secure, http -> https, to keep up with GitHub

### DIFF
--- a/bin/gitio
+++ b/bin/gitio
@@ -24,7 +24,7 @@ if code
   code = "-F code=#{code}"
 end
 
-output = `curl -i http://git.io -F 'url=#{url}' #{code} 2> /dev/null`
+output = `curl -i https://git.io -F 'url=#{url}' #{code} 2> /dev/null`
 if output =~ /Location: (.+)\n?/
   puts $1
   `echo #$1 | pbcopy`


### PR DESCRIPTION
The git.io URL in `git-io` no longer works because it uses `http`. When making a request to `git.io` using HTTP I kept being given a 301 pointing to the `https` URL like so:

```
HTTP/1.1 301 Moved Permanently
Server: Cowboy
Connection: close
Date: Sun, 31 Jan 2016 21:39:06 GMT
Status: 301 Moved Permanently
Content-Type: text/html
Location: https://git.io/
Via: 1.1 vaguer
```

Anyway, changing it to `https` in the `git-io` file fixed it. Seems GitHub updated their policy here. All good now.