### PR TITLE
Split gitconfig into common and local sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ atom.symlink/packages
 atom.symlink/storage
 atom.symlink/themes
 
-git/gitconfig.symlink
+git/gitconfig.local.symlink

--- a/git/gitconfig.local.symlink.example
+++ b/git/gitconfig.local.symlink.example
@@ -1,0 +1,5 @@
+[user]
+        name = AUTHORNAME
+        email = AUTHOREMAIL
+[credential]
+        helper = GIT_CREDENTIAL_HELPER

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -1,13 +1,8 @@
-# Sample gitconfig
-#
-
+# Local/private config goes in the include
+[include]
+        path = ~/.gitconfig.local
 [hub]
         protocol = https
-[user]
-        name = AUTHORNAME
-        email = AUTHOREMAIL
-[credential]
-        helper = GIT_CREDENTIAL_HELPER
 [alias]
         co = checkout
         promote = !$ZSH/bin/git-promote

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,7 +28,7 @@ fail () {
 }
 
 setup_gitconfig () {
-  if ! [ -f git/gitconfig.symlink ]
+  if ! [ -f git/gitconfig.local.symlink ]
   then
     info 'setup gitconfig'
 
@@ -43,7 +43,7 @@ setup_gitconfig () {
     user ' - What is your github author email?'
     read -e git_authoremail
 
-    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/gitconfig.symlink.example > git/gitconfig.symlink
+    sed -e "s/AUTHORNAME/$git_authorname/g" -e "s/AUTHOREMAIL/$git_authoremail/g" -e "s/GIT_CREDENTIAL_HELPER/$git_credential/g" git/gitconfig.local.symlink.example > git/gitconfig.local.symlink
 
     success 'gitconfig'
   fi


### PR DESCRIPTION
git allows you to include other config files from your main config file. The benefit of this change is that it lets you keep your main .gitconfig file in the dotfiles repository, while still keeping private info separate.

I'm flexible on the naming of the files here. Relates to #6.

This will probably create merge conflicts when people update.