### PR TITLE
back up and install Atom packages from a list

### DIFF
--- a/bin/atom-package-backup
+++ b/bin/atom-package-backup
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# Usage: atom-package-backup
+#
+# Saves a list of your currently installed atom packages to
+# ~/.dotfiles/atom.symlink/packages.txt suitable for install
+# via atom-package-install
+
+set -e
+
+apm list --installed --bare > ~/.dotfiles/atom.symlink/packages.txt

--- a/bin/atom-package-install
+++ b/bin/atom-package-install
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Usage: atom-package-install
+#
+# Installs the atom packages listed in your packages.txt file
+# located at ~/.dotfiles/atom.symlink/packages.txt
+#
+# You can generate a new list based on currently installed
+# packages via atom-package-backup
+
+set -e
+
+apm install --packages-file ~/.dotfiles/atom.symlink/packages.txt


### PR DESCRIPTION
Export a list of your currently installed Atom packages from APM with `atom-package-backup`, save it with your dotfiles and install from it later with `atom-package-install`.