### PR TITLE
Revise 'search' Command to Use Multiple Arguments

### DIFF
--- a/bin/search
+++ b/bin/search
@@ -1,12 +1,12 @@
 #!/bin/sh
 #
-# Quick search in a directory for a string ($1).
+# Quick search in a directory for a string ($@).
 #
 set -e
 
 # use -iru to search directories ack usually ignores (like .git)
 if [ -x /usr/bin/ack-grep ]; then
-    ack-grep -i $1
+    ack-grep -i "$@"
 else
-    ack -i $1
+    ack -i "$@"
 fi


### PR DESCRIPTION
* This places quotations around input argument to allow for multiple arguments
to be used when searching.
* A string can be inserted using quotations after the search commands.
    * Example: `search "foo bar"` will search for the entire string
* Additional arguments can be added.
    * Example: `search "foo bar" directory/` will search for the entire string
    in the specific subdirectory.

More information about argument wrapping here: http://stackoverflow.com/a/14247867