### PR TITLE
Updating .gitignore for new Atom folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ atom.symlink/compile-cache/
 atom.symlink/packages
 atom.symlink/storage
 atom.symlink/themes
+atom.symlink/blob-store
+atom.symlink/recovery
 
 git/gitconfig.local.symlink


### PR DESCRIPTION
So, I encountered this recently when updating my Dotfiles from disk. 

```
[..]
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	atom.symlink/blob-store/
	atom.symlink/recovery/

Stephens-Work-Mac-mini:.dotfiles (master) stephen$ ls -l atom.symlink/recovery/
total 8
-rw-r--r--  1 stephen  staff  121 Sep 12 14:55 credentials-7c3859.csv
```

That's an AWS credential file from when Atom crashed. 😳 

The `blob-store` directory doesn't have anything else of terrible interest, but seems like something you wouldn't want around on the repository.

## tl;dr

I think these paths should be added to the default `.gitignore`

```
atom.symlink/blob-store
atom.symlink/recovery
```