### PR TITLE
feature(branchPrefix): Added git branch prefixing script.

### DIFF
--- a/bin/git-new-branch
+++ b/bin/git-new-branch
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# When I develop new branches, I often forget their names. With this script,
+# as long as you know the current month, you can start typing it, and then
+# use tabbed autocomplete to get the rest of the way there.
+#
+# git-new-branch myNewBranch  ---> 10202016-myNewBranch
+# To find it again, tab complete on the month October by typing 10<tab>
+
+DATE=`date +%m%d%Y`
+git checkout -b "${DATE}-$*"
+


### PR DESCRIPTION
Here's something that I've found quite useful. Let me know what you guys think!

When I develop new branches, I often forget their names. With this script, as long as you know the current month, you can start typing it, and then use tabbed autocomplete to get the rest of the way there.

git-new-branch myNewBranch  ---> 10202016-myNewBranch
To find it again, tab complete on the month October by typing 10<tab>