### PR TITLE
Removed GOPATH from Atom's config.cson

### DIFF
--- a/atom.symlink/config.cson
+++ b/atom.symlink/config.cson
@@ -26,8 +26,6 @@
     invisibles: {}
     showIndentGuide: true
     softWrapAtPreferredLineLength: true
-  "go-plus":
-    goPath: "/Users/holman/Code/go"
   "linter-eslint":
     useGlobalEslint: true
   "release-notes":


### PR DESCRIPTION
Don't think it's necessary(?) as $GOPATH is set in https://github.com/holman/dotfiles/blob/master/go/path.zsh

https://github.com/joefitzgerald/go-config/wiki/GOPATH