### PR TITLE
Output dep install progress

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -144,7 +144,7 @@ install_dotfiles
 if [ "$(uname -s)" == "Darwin" ]
 then
   info "installing dependencies"
-  if source bin/dot > /tmp/dotfiles-dot 2>&1
+  if source bin/dot | while read -r data; do info "$data"; done
   then
     success "dependencies installed"
   else


### PR DESCRIPTION
During bootstrap, the dependency installation may look like a hang if the network is slow, or the number/size of dependencies are big. This change will display the same output as `dot` during the bootstrap process, showing a more verbose and progressive output to the user.