### PR TITLE
Allow nested symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ There's a few special files in the hierarchy.
 - **topic/install.sh**: Any file named `install.sh` is executed when you run `script/install`. To avoid being loaded automatically, its extension is `.sh`, not `.zsh`.
 - **topic/\*.symlink**: Any file ending in `*.symlink` gets symlinked into
   your `$HOME`. This is so you can keep all of those versioned in your dotfiles
-  but still keep those autoloaded files in your home directory. These get
-  symlinked in when you run `script/bootstrap`.
+  but still keep those autoloaded files in your home directory. To further nest symlinks into subdirectories under `$HOME`, use `+` signs to signify additional directory delimiters. So for example, the file `topic/config+topic.symlink` would get symlinked to `$HOME/.config/topic` when you run `script/bootstrap`.
 
 ## install
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -120,6 +120,11 @@ link_file () {
 
   if [ "$skip" != "true" ]  # "false" or empty
   then
+    parent=$(dirname "$2")
+    if [ ! -d "$parent" ]
+    then
+      mkdir -p "$parent"
+    fi
     ln -s "$1" "$2"
     success "linked $1 to $2"
   fi
@@ -132,7 +137,8 @@ install_dotfiles () {
 
   for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink' -not -path '*.git*')
   do
-    dst="$HOME/.$(basename "${src%.*}")"
+    dst=$(basename "${src%.*}")
+    dst="$HOME/.${dst//+//}"
     link_file "$src" "$dst"
   done
 }


### PR DESCRIPTION
This allows you to create symlinks not just in the top level `$HOME` directory, but also inside nested directories so you can track files like `$HOME/.ssh/config`.  You use `+` signs to signify additional directory delimiters on files with the `.symlink` extension. A great example is instead of symlinking the entire `~/.config` directory into source control, you can now just track the nested `~/.config/nvim` directory.

Examples:
`.dotfiles/ssh+config.symlink` -> `~/.ssh/config`
`.dotfiles/ssh/ssh+config.symlink` -> `~/.ssh/config`
`.dotfiles/vim/config+nvim.symlink` -> `~/.config/nvim`
`.dotfiles/vim/config+nvim+init.vim.symlink` -> `~/.config/nvim/init.vim`

* Backwards compatible with how it currently works.
* Creates nested parent directories if they don't exist.
* Symlinks both directories and files.

