### PR TITLE
Ignore battery status prompt without sysctl access

### DIFF
--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -1,3 +1,6 @@
 alias reload!='. ~/.zshrc'
 
 alias cls='clear' # Good 'ol Clear Screen command
+
+alias ls='/bin/ls -h'
+alias ll='ls -lA'

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -2,7 +2,7 @@
 export ZSH=$HOME/.dotfiles
 
 # your project folder that we can `c [tab]` to
-export PROJECTS=~/Code
+export PROJECTS=~/code
 
 # Stash your environment variables in ~/.localrc. This means they'll stay out
 # of your main dotfiles repository (which may be public, like this one), but


### PR DESCRIPTION
Some systems don't allow direct access to the sysctl command at the regular user level. This gets around that by checking if we can access the command directly from zshes $+commands magic variable.