### PR TITLE
Ignore adding the battery status to the ZSH Prompt if we don't have sysctl access.

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -55,7 +55,7 @@ directory_name() {
 }
 
 battery_status() {
-  if [[ $(sysctl -n hw.model) == *"Book"* ]]
+	if (( $+commands[sysctl] )) && [[ $(sysctl -n hw.model) == *"Book"* ]]
   then
     $ZSH/bin/battery-status
   fi

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -55,7 +55,7 @@ directory_name() {
 }
 
 battery_status() {
-	if (( $+commands[sysctl] )) && [[ $(sysctl -n hw.model) == *"Book"* ]]
+  if (( $+commands[sysctl] )) && [[ $(sysctl -n hw.model) == *"Book"* ]]
   then
     $ZSH/bin/battery-status
   fi


### PR DESCRIPTION
Some systems don't allow direct access to the sysctl command at the regular user level. This gets around that by checking if we can access the command directly from zshes $+commands magic variable.