### PR TITLE
Correctly handle spaces in file paths

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -130,6 +130,9 @@ install_dotfiles () {
 
   local overwrite_all=false backup_all=false skip_all=false
 
+# If code is added later that relies on the current value of IFS, be sure to save it
+# and then restore it after this loop.
+  local IFS=$'\n'
   for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.symlink' -not -path '*.git*')
   do
     dst="$HOME/.$(basename "${src%.*}")"


### PR DESCRIPTION
Since `install_dotfiles()` in `bootstrap` treats the output of `find` as a list rather than an array, paths with spaces in them will break. The simplest solution is to change the Internal Field Separator to a newline, as it is extremely unlikely that any filenames will contain that character.

Alternatively, the result of `find` could be put into an array, as demonstrated by this [answer](https://stackoverflow.com/a/23357277), but this seems like a reasonable fix for the vast majority of cases.