### PR TITLE
Change ZSH to DOTZSH

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -38,16 +38,16 @@ while test $# -gt 0; do
 	shift
 done
 
-export ZSH=$HOME/.dotfiles
+export DOTZSH=$HOME/.dotfiles
 
 # Set macOS defaults
-$ZSH/macos/set-defaults.sh
+$DOTZSH/macos/set-defaults.sh
 
 # Set macOS hostname
-$ZSH/macos/set-hostname.sh
+$DOTZSH/macos/set-hostname.sh
 
 # Install homebrew
-$ZSH/homebrew/install.sh 2>&1
+$DOTZSH/homebrew/install.sh 2>&1
 
 # Upgrade homebrew
 echo "› brew update"
@@ -55,4 +55,4 @@ brew update
 
 # Install software
 echo "› script/install"
-$ZSH/script/install
+$DOTZSH/script/install

--- a/bin/set-defaults
+++ b/bin/set-defaults
@@ -1,5 +1,5 @@
 #!/bin/sh
 #
-# Sets macOS defaults by running $ZSH/macos/set-defaults.sh.
+# Sets macOS defaults by running $DOTZSH/macos/set-defaults.sh.
 
-exec $ZSH/macos/set-defaults.sh
+exec $DOTZSH/macos/set-defaults.sh

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -5,9 +5,9 @@
         protocol = https
 [alias]
         co = checkout
-        promote = !$ZSH/bin/git-promote
-        wtf     = !$ZSH/bin/git-wtf
-        rank-contributors = !$ZSH/bin/git-rank-contributors
+        promote = !$DOTZSH/bin/git-promote
+        wtf     = !$DOTZSH/bin/git-wtf
+        rank-contributors = !$DOTZSH/bin/git-rank-contributors
         count   = !git shortlog -sn
 [color]
         diff = auto

--- a/system/_path.zsh
+++ b/system/_path.zsh
@@ -1,2 +1,2 @@
-export PATH="./bin:/usr/local/bin:/usr/local/sbin:$ZSH/bin:$PATH"
+export PATH="./bin:/usr/local/bin:/usr/local/sbin:$DOTZSH/bin:$PATH"
 export MANPATH="/usr/local/man:/usr/local/mysql/man:/usr/local/git/man:$MANPATH"

--- a/zsh/config.zsh
+++ b/zsh/config.zsh
@@ -1,9 +1,9 @@
 export LSCOLORS="exfxcxdxbxegedabagacad"
 export CLICOLOR=true
 
-fpath=($ZSH/functions $fpath)
+fpath=($DOTZSH/functions $fpath)
 
-autoload -U $ZSH/functions/*(:t)
+autoload -U $DOTZSH/functions/*(:t)
 
 HISTFILE=~/.zsh_history
 HISTSIZE=10000

--- a/zsh/fpath.zsh
+++ b/zsh/fpath.zsh
@@ -1,2 +1,2 @@
 #add each topic folder to fpath so that they can add functions and completion scripts
-for topic_folder ($ZSH/*) if [ -d $topic_folder ]; then  fpath=($topic_folder $fpath); fi;
+for topic_folder ($DOTZSH/*) if [ -d $topic_folder ]; then  fpath=($topic_folder $fpath); fi;

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -62,7 +62,7 @@ battery_status() {
 
   if [[ $(sysctl -n hw.model) == *"Book"* ]]
   then
-    $ZSH/bin/battery-status
+    $DOTZSH/bin/battery-status
   fi
 }
 

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -1,5 +1,5 @@
-# shortcut to this dotfiles path is $ZSH
-export ZSH=$HOME/.dotfiles
+# shortcut to this dotfiles path is $DOTZSH
+export DOTZSH=$HOME/.dotfiles
 
 # your project folder that we can `c [tab]` to
 export PROJECTS=~/Code
@@ -14,7 +14,7 @@ fi
 
 # all of our zsh files
 typeset -U config_files
-config_files=($ZSH/**/*.zsh)
+config_files=($DOTZSH/**/*.zsh)
 
 # load the path files
 for file in ${(M)config_files:#*/path.zsh}


### PR DESCRIPTION
I am using OhMyZSH and started to use your awesome dotfiles as well now. 

These two tool clash because they both use `$ZSH` env.

Here the OhMyZSH one:
https://github.com/ohmyzsh/ohmyzsh/blob/43613d7b710f9a06971fac48dea3301bbc15b579/templates/zshrc.zsh-template#L4-L5

I already changed my fork with this, but maybe other can benefit from this change as well.

Looking forward to your feedback.