### PR TITLE
fix sourcing grc.zsh

### DIFF
--- a/system/grc.zsh
+++ b/system/grc.zsh
@@ -1,5 +1,10 @@
-# GRC colorizes nifty unix tools all over the place
-if (( $+commands[grc] )) && (( $+commands[brew] ))
-then
-  source `brew --prefix`/etc/grc.bashrc
+# GRC colorizes command output when available.
+if (( $+commands[grc] )) && (( $+commands[brew] )); then
+  grc_prefix="$(brew --prefix)"
+
+  if [[ -f "$grc_prefix/etc/grc.zsh" ]]; then
+    source "$grc_prefix/etc/grc.zsh"
+  fi
+
+  unset grc_prefix
 fi


### PR DESCRIPTION
This apparently changed 11 years ago, so maybe grc isn't in use and should be removed...?