### PR TITLE
fix dot and homebrew for linux

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # dot
 #
@@ -44,11 +44,11 @@ export ZSH=$HOME/.dotfiles
 echo "› git pull"
 git -C $ZSH pull
 
-# Set macOS defaults
-$ZSH/macos/set-defaults.sh
-
-# Set macOS hostname
-$ZSH/macos/set-hostname.sh
+# Set macOS defaults and hostname
+if [ "$(uname -s)" = "Darwin" ]; then
+  $ZSH/macos/set-defaults.sh
+  $ZSH/macos/set-hostname.sh
+fi
 
 # Install homebrew
 $ZSH/homebrew/install.sh 2>&1

--- a/homebrew/install.sh
+++ b/homebrew/install.sh
@@ -10,14 +10,7 @@ if test ! $(which brew)
 then
   echo "  Installing Homebrew for you."
 
-  # Install the correct homebrew for each OS type
-  if test "$(uname)" = "Darwin"
-  then
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-  elif test "$(expr substr $(uname -s) 1 5)" = "Linux"
-  then
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install)"
-  fi
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 fi
 

--- a/homebrew/path.zsh
+++ b/homebrew/path.zsh
@@ -1,1 +1,20 @@
-export PATH="/opt/homebrew/bin:$PATH"
+_brew_cache="$HOME/.cache/brew-shellenv.sh"
+
+if [[ -x /opt/homebrew/bin/brew ]]; then
+  _brew=/opt/homebrew/bin/brew
+elif [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+  _brew=/home/linuxbrew/.linuxbrew/bin/brew
+else
+  _brew=""
+fi
+
+if [[ -n "$_brew" ]]; then
+  if [[ ! -f "$_brew_cache" || "$_brew" -nt "$_brew_cache" ]]; then
+    mkdir -p "${_brew_cache:h}"
+    "$_brew" shellenv >| "$_brew_cache"
+  fi
+  source "$_brew_cache"
+fi
+
+unset _brew _brew_cache
+


### PR DESCRIPTION
dot uses bash substitutions but uses `sh` which is often `dash` on linux
moves the os x specific calls in dot to a darwin check
normalizes homebrew install... duplicate of this unmerged PR #336 
use `brew shellenv` for fully sourcing homebrew information `brew doctor` will pass on os x and linux after this. caching b/c performance :) 