### PR TITLE
add *.configsymlink convention for ~/.config/ dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ There's a few special files in the hierarchy.
   your `$HOME`. This is so you can keep all of those versioned in your dotfiles
   but still keep those autoloaded files in your home directory. These get
   symlinked in when you run `script/bootstrap`.
+- **topic/\*.configsymlink**: Any file ending in `*.configsymlink` gets
+  symlinked into your `$HOME/.config/`. Follows the same convention as
+  `*.symlink` but targets the XDG config directory for tools that store their
+  config there (e.g. `ghostty/config.ghostty.configsymlink` →
+  `~/.config/config.ghostty`).
 
 ## install
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -137,8 +137,22 @@ install_dotfiles () {
   done
 }
 
+install_config_dotfiles () {
+  info 'installing config dotfiles'
+
+  local overwrite_all=false backup_all=false skip_all=false
+
+  for src in $(find -H "$DOTFILES_ROOT" -maxdepth 2 -name '*.configsymlink' -not -path '*.git*')
+  do
+    dst="$HOME/.config/$(basename "${src%.*}")"
+    mkdir -p "$(dirname "$dst")"
+    link_file "$src" "$dst"
+  done
+}
+
 setup_gitconfig
 install_dotfiles
+install_config_dotfiles
 
 # If we're on a Mac, let's install and setup homebrew.
 if [ "$(uname -s)" == "Darwin" ]


### PR DESCRIPTION
Introduces install_config_dotfiles() which mirrors the existing *.symlink -> $HOME behavior, but links *.configsymlink files into $HOME/.config/ for tools that follow XDG config conventions.